### PR TITLE
docs: fix broken clone step + flesh out prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,20 +11,37 @@ Welcome to the ARKit Planet Tracker! This iOS app uses ARKit to provide a real-t
 ## Prerequisites
 
 Before you begin, ensure you have the following installed:
-- Xcode
+- Xcode 15 or later (the project targets **iOS 17.4** and uses **Swift 5.0**)
 - CocoaPods
+
+The project depends on [SwiftAA](https://github.com/onekiloparsec/SwiftAA) for
+astronomical calculations; it is pulled in automatically by CocoaPods.
 
 ## Getting Started
 
 Follow these steps to get your app up and running:
 
 1. **Clone the repository**:
-git clone
+   ```bash
+   git clone https://github.com/TomBastable/ARKit-SolarSystem---ISS.git
+   cd ARKit-SolarSystem---ISS
+   ```
 2. **Install dependencies**:
-pod install
-3. Open the XCWorkspace
+   ```bash
+   pod install
+   ```
+3. **Open the workspace** (not the `.xcodeproj`):
+   ```bash
+   open "Knight Sky.xcworkspace"
+   ```
+4. Build and run on a physical iOS device — ARKit is not supported in the
+   Simulator.
 
 ## Demo Video
 
 Check out this brief demo of the project in action:
 [Watch the Demo Video](https://www.youtube.com/shorts/fZNzSpYLfeo)
+
+## License
+
+Released under the MIT License — see [LICENSE](LICENSE) for the full text.


### PR DESCRIPTION
## Summary
- Fixes a broken step 1 in **Getting Started** — the line read literally `git clone` with no URL, so the instructions couldn't be followed end-to-end.
- Wraps the shell commands in fenced code blocks so they render and are copy-pastable.
- Calls out the iOS 17.4 / Swift 5.0 target and Xcode 15 requirement.
- Notes the SwiftAA dependency that CocoaPods pulls in.
- Adds an explicit reminder to open the `.xcworkspace` (not the project) after `pod install`.
- Adds a reminder that ARKit needs a physical device — Simulator won't run it.
- Adds a **License** section linking to the existing MIT `LICENSE` file.

## Why
Anyone following the README from a fresh clone today hits the broken step 1 immediately. The other additions remove the obvious follow-up footguns (wrong file opened, running on Simulator).

## Test plan
- [x] Verified the new clone URL is the canonical repo URL.
- [x] Cross-checked the iOS / Swift version against `Knight Sky.xcodeproj/project.pbxproj`.
- [x] Confirmed `LICENSE` exists and is MIT (copyright 2024 Tom Bastable).